### PR TITLE
fix: add netlify badge to footer

### DIFF
--- a/themes/docsy/assets/scss/_footer.scss
+++ b/themes/docsy/assets/scss/_footer.scss
@@ -96,8 +96,12 @@
             margin-left: var(--of--spacer--sm);
         }
     }
+    &__badge {
+        margin-left: auto;
+    }
     .of-link-list {
         display: flex;
         flex-wrap: wrap;
     }
 }
+

--- a/themes/docsy/layouts/partials/footer.html
+++ b/themes/docsy/layouts/partials/footer.html
@@ -24,6 +24,9 @@
       <li class="of-link-list__li"><a href="https://www.redhat.com/en/about/privacy-policy">Privacy Statement</a></li>
       <!-- <li class="of-link-list__li"><a href="/terms/">Terms of Use</a></li> -->
     </ul>
+    <a class="of-footer-main__badge" href="https://www.netlify.com">
+        <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify">
+    </a>
   </div>
 </footer>
 </body>


### PR DESCRIPTION
Add the netlify badge to footer so that the site can be submitted for the
netlify OpenSource hosting plan.