### PR TITLE
fix: edit landing page text

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -6,14 +6,14 @@ draft: false
 
 <section class="of-masthead of-masthead--home">
   <h1 class="of-heading of-masthead--home__title"><span>Operator</span><span>LIFECYCLE MANAGER</span></h1>
-  <h2 class="of-heading of-heading--md of-masthead--home__content">Operator Lifecycle Manager (OLM) extends Kubernetes to provide a declarative way to install, manage, and upgrade Operators and their dependencies in a cluster.</h2>
+  <h2 class="of-heading of-heading--md of-masthead--home__content">The Operator Lifecycle Manager (OLM) extends Kubernetes to provide a declarative way to install, manage, and upgrade Operators on a cluster.</h2>
   <a href="/docs/getting-started" class="of-button of-button--primary of-masthead--home__action1">Install an Operator</a>
   <!-- <a href="#" class="of-button of-button--secondary of-masthead--home__action2" aria-label="how can I build an operator">Second CTA</a> -->
 </section>
   <section class="of-section-page-intro ">
     <header class="of-section-page-intro__header">
       <h2 class="of-heading of-heading--md">WHAT IS OPERATOR Lifecycle manager?</h2>
-    <p>This project is a component of the <a href="https://www.operatorframework.io/">Operator Framework</a>, an open source toolkit to manage Kubernetes native applications, called Operators, in an effective, automated, and scalable way.</p>
+    <p>This project is a component of the <a href="https://www.operatorframework.io/">Operator Framework</a>, an open source toolkit to manage Kubernetes native applications, called Operators, in a streamlined and scalable way.</p>
     </header>
   </section>
   <!-- <section class="of-section of-section-whats-operator of-section-separator"> -->
@@ -37,7 +37,7 @@ draft: false
       <div class="of-section-page-intro__item of-section-page-intro__item__build">
           <h3 class="of-heading of-heading--md">OVER-THE-AIR UPDATES AND CATALOGS</h3>
           <div class="of-section-page-intro__item__content">
-          <p>Kubernetes clusters are being kept up to date using elaborate update mechanisms today, more often automatically and in the background.</p>  
+          <p>OLM provides rich update mechanisms to keep Kubernetes native applications up to date automatically.</p>  
         </div>
       </div>
       <div class="of-section-page-intro__item of-section-page-intro__item__manage">
@@ -49,19 +49,19 @@ draft: false
       <div class="of-section-page-intro__item of-section-page-intro__item__discover">
           <h3 class="of-heading of-heading--md">DISCOVERABILITY</h3>
           <div class="of-section-page-intro__item__content">
-          <p>OLM advertises installed Operators and their services into the namespaces of tenants.</p>     
+          <p>OLM makes Operators and their services available for cluster users to select and install.</p>     
         </div>
       </div>
       <div class="of-section-page-intro__item of-section-page-intro__item__discover">
         <h3 class="of-heading of-heading--md">CLUSTER STABILITY</h3>
         <div class="of-section-page-intro__item__content">
-        <p>Operators must claim ownership of their APIs. OLM will prevent conflicting Operators owning the same APIs being installed, ensuring cluster stability.</p>   
+        <p>OLM will prevent conflicting Operators owning the same APIs being installed, ensuring cluster stability.</p>   
       </div>
     </div>
     <div class="of-section-page-intro__item of-section-page-intro__item__discover">
       <h3 class="of-heading of-heading--md">DECLARATIVE UI CONTROLS</h3>
       <div class="of-section-page-intro__item__content">
-      <p>Operators can behave like managed service providers. Their user interface on the command line are APIs.</p>
+      <p>OLM enables Operators to behave like managed service providers through the APIs they expose.</p>
     </div>
   </div>
     </div>
@@ -98,5 +98,5 @@ height="18px" viewBox="0 0 26 18" style="enable-background:new 0 0 26 18;" xml:s
 </svg>
     </header>
     
-    <p class="of-section__contribute__content">OLM and its components are open source, so please feel encouraged to jump into each individually and learn what else you can do. If you want to discuss your experience, have questions, or want toget involved, join the <a href="https://groups.google.com/forum/#!forum/operator-framework" class="of-link of-link--inline">Operator Framework forum</a> and visit us on <a href="https://github.com/operator-framework/operator-lifecycle-manager" class="of-link of-link--inline">GitHub</a>.</p>
+    <p class="of-section__contribute__content">The Operator Lifecycle Manager project is open source, and participation from members of the community is highly valued. If you want to get involved, discuss your experiences with OLM, or have questions, join the <a href="https://groups.google.com/forum/#!forum/operator-framework" class="of-link of-link--inline">Operator Framework forum</a> and visit us on <a href="https://github.com/operator-framework/operator-lifecycle-manager" class="of-link of-link--inline">GitHub</a>.</p>
   </section>


### PR DESCRIPTION
Various improvements to text on just the landing page: simplify and make the descriptions more clear for new OLM users. 