### PR TITLE
Explaining the need for operator group during install docs

### DIFF
--- a/content/en/docs/Tasks/install-operator-with-olm.md
+++ b/content/en/docs/Tasks/install-operator-with-olm.md
@@ -6,9 +6,9 @@ description: >
   [Once you've made your operator available in a catalog](/docs/tasks/make-operator-part-of-catalog/), or you've chosen an operator from the [list of operators available to be installed in the cluster](/docs/tasks/list-operators-available-to-install/), you can install your operator by creating a [`Subscription`](/docs/concepts/customresourcedefinitions/subscription/) to a specific [channel](/docs/concepts/glossary/#channel). 
 ---
 
-Before installing into a namespace, you will need to create an [operator group](/docs/concepts/crds/operatorgroup) in that namespace. The operator group must provide the namespaces that match the operator that you trying to install `installModes`.
+Before installing an operator into a namespace, you will need to create an [OperatorGroup resource](/docs/concepts/crds/operatorgroup) in that namespace. The OperatorGroup must target namespaces such that it matches the operator's `installModes`.
 
-For example installing an operator into `foo` namespace that will be cluster scoped you would create a operator group like:
+For example, to install a cluster scoped operator into the `foo` namespace create an OperatorGroup like:
 
 
 ```yaml
@@ -17,11 +17,9 @@ kind: OperatorGroup
 metadata:
   name: my-group
   namespace: foo
-spec:
-  targetNamespaces:
 ```
 
-After creating this resource you can create subscriptions to install cluster scoped operators.
+After creating this resource you can create Subscriptions to install cluster scoped operators.
 
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1
@@ -35,6 +33,7 @@ spec:
   source: <name-of-catalog-operator-is-part-of>
   sourceNamespace: <namespace-that-has-catalog>
  ``` 
+
 For example, if you want to install an operator named `my-operator`, from a catalog named `my-catalog` that is in the namespace `olm`, and you want to subscribe to the channel `stable`, your subscription yaml would look like this: 
 
 ```yaml

--- a/content/en/docs/Tasks/install-operator-with-olm.md
+++ b/content/en/docs/Tasks/install-operator-with-olm.md
@@ -6,6 +6,23 @@ description: >
   [Once you've made your operator available in a catalog](/docs/tasks/make-operator-part-of-catalog/), or you've chosen an operator from the [list of operators available to be installed in the cluster](/docs/tasks/list-operators-available-to-install/), you can install your operator by creating a [`Subscription`](/docs/concepts/customresourcedefinitions/subscription/) to a specific [channel](/docs/concepts/glossary/#channel). 
 ---
 
+Before installing into a namespace, you will need to create an [operator group](/docs/concepts/crds/operatorgroup) in that namespace. The operator group must provide the namespaces that match the operator that you trying to install `installModes`.
+
+For example installing an operator into `foo` namespace that will be cluster scoped you would create a operator group like:
+
+
+```yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: my-group
+  namespace: foo
+spec:
+  targetNamespaces:
+```
+
+After creating this resource you can create subscriptions to install cluster scoped operators.
+
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription


### PR DESCRIPTION
Adding information on:
1. That you need to create an operator group before installation into a namespace
2. that the operator group is tied to the install mode of the operator 
3. Link to the operator group docs for further information

