### PR TITLE
change catalog example to index image

### DIFF
--- a/content/en/docs/Concepts/crds/CatalogSource.md
+++ b/content/en/docs/Concepts/crds/CatalogSource.md
@@ -23,7 +23,7 @@ metadata:
   namespace: olm
 spec:
   sourceType: grpc
-  image: quay.io/operator-framework/upstream-community-operators:latest
+  image: quay.io/operatorhubio/catalog:latest
   displayName: Community Operators
   publisher: OperatorHub.io
 ```


### PR DESCRIPTION
At quay.io/operatorhubio/catalog:latest there is now an index image maintained by the pipeline reflecting the content of https://github.com/operator-framework/community-operators