### PR TITLE
fix link from pointing to sdk docs and instead point to olm docs

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -9,6 +9,6 @@ weight: 20
 
 {{% alert title="Warning" color="warning" %}}
 These pages are under construction. Please continue to use the [docs in
-tree](https://github.com/operator-framework/operator-sdk/tree/master/doc)
+tree](https://github.com/operator-framework/operator-lifecycle-manager/tree/master/doc)
 for now.
 {{% /alert %}}


### PR DESCRIPTION
this is a link fix, I found that the link was pointing to the wrong location, instead of operator-sdk it should be pointing to operator-lifecycle-manager.