### PR TITLE
remove errant underline from header links

### DIFF
--- a/assets/scss/_docs.scss
+++ b/assets/scss/_docs.scss
@@ -19,6 +19,10 @@
         font-weight: 800;
         letter-spacing: 2px;
         margin: var(--of--spacer--md) 0 var(--of--spacer--sm);
+
+        a:hover {
+            text-decoration: none;
+        }
     }
     
     h5, h6 {


### PR DESCRIPTION
When hovering over a link icon, the whitespace next to it would be underlined, which looked weird.