### PR TITLE
Replace nonexistent field in example subscription

### DIFF
--- a/content/en/docs/Tasks/install-operator-with-olm.md
+++ b/content/en/docs/Tasks/install-operator-with-olm.md
@@ -128,7 +128,7 @@ spec:
   name: my-operator
   source: my-catalog
   sourceNamespace: olm
-  approval: Manual
+  installPlanApproval: Manual
   startingCSV: 1.1.0
 ```
 


### PR DESCRIPTION
This commit removes the nonexistent `spec.approval` field in an example subscription
with the `spec.installPlanApproval` field.