### PR TITLE
Replace `spec.approval` field in subscription resource with `spec.installPlanApproval`

### DIFF
--- a/content/en/docs/Concepts/crds/subscription.md
+++ b/content/en/docs/Concepts/crds/subscription.md
@@ -25,7 +25,7 @@ This Subscription object defines the name and namespace of the operator, as well
 
 ## Manually Approving Upgrades via Subscriptions
 
-By default, OLM will automatically approve updates to an operator as new versions become available via a CatalogSource. When creating a subscription, it is possible to disable automatic updates by setting the `approval` field to `Manual` like so:
+By default, OLM will automatically approve updates to an operator as new versions become available via a CatalogSource. When creating a subscription, it is possible to disable automatic updates by setting the `installPlanApproval` field to `Manual` like so:
 
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1
@@ -38,10 +38,10 @@ spec:
   name: my-operator
   source: my-catalog
   sourceNamespace: operators
-  approval: Manual
+  installPlanApproval: Manual
 ```
 
-Setting the `approval` field to manual will prevent OLM from automatically installing the operator. As such, you will need to approve the installPlan which can be done with the following commands:
+Setting the `installPlanApproval` field to manual will prevent OLM from automatically installing the operator. As such, you will need to approve the installPlan which can be done with the following commands:
 
 ```bash
 kubectl -n operators get installplans


### PR DESCRIPTION
Hi, thank you for providing such the great product 👍 

When I added a subscription resource to my cluster, I got the following error:

```
error: error validating "...": error validating data: ValidationError(Subscription.spec): unknown field "approval" in com.coreos.operators.v1alpha1.Subscription.spec; if you choose to ignore these errors, turn validation off with --validate=false
```

Seeing [the CRD definition](https://github.com/operator-framework/operator-lifecycle-manager/blob/7988750a76c02530a72e77fff67705d4b2c0a9c9/manifests/0000_50_olm_00-subscriptions.crd.yaml#L1635-L1638), `spec.installPlanApproval` seems be correct and worked on my cluster.
If this would help this project.