### PR TITLE
README,hack: Update the linting script and add instructions for running locally

### DIFF
--- a/content/en/docs/contribution-guidelines/local-docs.md
+++ b/content/en/docs/contribution-guidelines/local-docs.md
@@ -7,8 +7,8 @@ linkTitle: Local Docs
 
 Clone the repository:
 
-```
-$ git clone https://github.com/operator-framework/olm-docs/
+```bash
+git clone https://github.com/operator-framework/olm-docs/
 ```
 
 The docs are built with [Hugo](https://gohugo.io/) which can be installed along with the
@@ -18,16 +18,33 @@ guide](https://www.docsy.dev/docs/getting-started/#prerequisites-and-installatio
 We use `git submodules` to install the docsy theme. From the
 root directory, update the submodules to install the theme.
 
-```
-$ git submodule update --init --recursive
+```bash
+git submodule update --init --recursive
 ```
 
 ## Build and Serve
 
 You can build and serve your docs to localhost:1313 with:
 
-```
+```bash
 hugo server
 ```
 
 Any changes will be included in real time.
+
+## Running the Linting Script Locally
+
+The ./hack/ci/link-check.sh script is responsible for building the site and running [html-proofer](https://github.com/gjtorikian/html-proofer) that validates the generated HTML output.
+
+In order to run the linting script locally, run the following command from the root directory:
+
+```sh
+${PWD}/hack/ci/link-check.sh
+```
+
+**Note**: In the case you're getting permission denied errors when reading from that mounted volume, set the following environment variable and re-run the linting script:
+
+```sh
+export CONTAINER_RUN_EXTRA_OPTIONS="--security-opt label=disable"
+./hack/ci/link-check.sh
+```

--- a/hack/ci/link-check.sh
+++ b/hack/ci/link-check.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -ev
 
+CONTAINER_RUN_EXTRA_OPTIONS=${CONTAINER_RUN_EXTRA_OPTIONS:=""}
+
 docker volume create olm-html
-docker run --rm -v "$(pwd):/src" -v olm-html:/src/public klakegg/hugo:0.73.0-ext-ubuntu
+docker run --rm ${CONTAINER_RUN_EXTRA_OPTIONS} -v "$(pwd):/src" -v olm-html:/src/public klakegg/hugo:0.73.0-ext-ubuntu
 docker run --rm -v olm-html:/target mtlynch/htmlproofer /target --empty-alt-ignore --http-status-ignore 429 --allow_hash_href
 docker volume rm olm-html


### PR DESCRIPTION
Update the hack/ci/lint-check.sh script and expose an environment
variable that injects extra container run options. This is particularly
useful in the case you want to run this as a privileged container, or
you want to disable any selinux permissions.

Update the README and give a brief description of what the linting
script is trying to accomplish and add a note about disabling selinux
permissions if you're getting permission denied errors when attempting
to mount the volume when building the site.