### PR TITLE
content: Fix broken links and internal links not resolving

### DIFF
--- a/content/en/about/_index.html
+++ b/content/en/about/_index.html
@@ -21,14 +21,14 @@ menu:
       <div class="of-section--largetext__item">
           <h2 class="of-heading of-heading--xl">Installing the SDK CLI</h2>
           <div class="of-section--largetext__content">
-            <p>Follow the steps in the <a href="https://sdk.operatorframework.io/docs/installation/install-operator-sdk/">installation guide</a> to learn how to install the Operator SDK CLI tool. If you are using a release version of the SDK, make sure to follow the documentation for that version. You make use any of the following installation processes:</p>
+            <p>Follow the steps in the <a href="https://sdk.operatorframework.io/docs/installation/">installation guide</a> to learn how to install the Operator SDK CLI tool. If you are using a release version of the SDK, make sure to follow the documentation for that version. You make use any of the following installation processes:</p>
           <ol class="of-list-ordered">
-            <li>Install the <a href="https://sdk.operatorframework.io/docs/installation/install-operator-sdk/#install-from-homebrew-macos">Homebrew</a> (macOS)</li>
-            <li>Install from <a href="https://sdk.operatorframework.io/docs/installation/install-operator-sdk/#install-from-github-release">GitHub</a> release</li>
-            <li>Compile and install from <a href="https://sdk.operatorframework.io/docs/installation/install-operator-sdk/#compile-and-install-from-master">master</a></li>
+            <li>Install the <a href="https://sdk.operatorframework.io/docs/installation/#install-from-homebrew-macos">Homebrew</a> (macOS)</li>
+            <li>Install from <a href="https://sdk.operatorframework.io/docs/installation/#install-from-github-release">GitHub</a> release</li>
+            <li>Compile and install from <a href="https://sdk.operatorframework.io/docs/installation/#compile-and-install-from-master">master</a></li>
           </ol>
           </div>
-          <a href="https://sdk.operatorframework.io/docs/installation/install-operator-sdk" class="of-button of-button--tertiary">Learn More
+          <a href="https://sdk.operatorframework.io/docs/installation/" class="of-button of-button--tertiary">Learn More
             <svg class="of-button__icon" enable-background="new 0 0 22 22" version="1.1" viewBox="0 0 22 22" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
                 <path d="M19.5,8l-7.3-7.6c-0.4-0.4-1.1-0.4-1.5,0L9.3,1.8c-0.4,0.4-0.4,1.1,0,1.6l5.2,5.5H1.1C0.5,8.9,0,9.3,0,10V12  c0,0.6,0.5,1.1,1.1,1.1h13.5l-5.2,5.5c-0.4,0.4-0.4,1.1,0,1.6l1.4,1.5c0.4,0.4,1.1,0.4,1.5,0l9.4-9.9c0.4-0.4,0.4-1.1,0-1.6L19.5,8z  "/>
                 </svg>

--- a/content/en/docs/Tasks/creating-operator-manifests.md
+++ b/content/en/docs/Tasks/creating-operator-manifests.md
@@ -190,7 +190,7 @@ spec:
       kind: Memcached
 ```
 
-Dependency resolution and ownership is discussed more in depth in the [Concepts section](/docs/Concepts/olm-architecture/dependency-resolution).
+Dependency resolution and ownership is discussed more in depth in the [Concepts section](/docs/concepts/olm-architecture/dependency-resolution).
 
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
Update the content/* documentation and update any broken links that the
CI linting hack script was exposing:

```bash
docker run --rm -v olm-html:/target mtlynch/htmlproofer /target --empty-alt-ignore --http-status-ignore 429 --allow_hash_href
Running ["ScriptCheck", "ImageCheck", "LinkCheck"] on ["/target"] on *.html... 


Checking 149 external links...
Ran on 43 files!


- /target/about/index.html
  *  External link https://sdk.operatorframework.io/docs/installation/install-operator-sdk failed: 404 No error
  *  External link https://sdk.operatorframework.io/docs/installation/install-operator-sdk/ failed: 404 No error
  *  External link https://sdk.operatorframework.io/docs/installation/install-operator-sdk/#compile-and-install-from-master failed: 404 No error
  *  External link https://sdk.operatorframework.io/docs/installation/install-operator-sdk/#install-from-github-release failed: 404 No error
  *  External link https://sdk.operatorframework.io/docs/installation/install-operator-sdk/#install-from-homebrew-macos failed: 404 No error
- /target/docs/tasks/creating-operator-manifests/index.html
  *  internally linking to /docs/Concepts/olm-architecture/dependency-resolution, which does not exist (line 816)
     <a href="/docs/Concepts/olm-architecture/dependency-resolution">Concepts section</a>
htmlproofer 3.15.0 | Error:  HTML-Proofer found 6 failures!
```

The operator-sdk installation docs have deflated the `*/installation/install-operator-sdk` to `*/installation` which was producing those 404 errors when referencing external links.

The path to the dependency-resolution documentation needed to be updated to use the correct directory from the creating operator manifests documentation path.