### PR TITLE
Migrate to using GitHub actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,15 @@
+name: lint
+on: pull_request
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Run the lint check script
+      run: |
+        set -eu
+
+        git submodule update --init --recursive && ${PWD}/hack/ci/link-check.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-services:
-  - docker
-
-script:
-  ./hack/ci/link-check.sh


### PR DESCRIPTION
Migrate to using Github actions to run the linting check on a per-PR basis.

Remove the .travis configuration file as it's no longer necessary with the introduction of the linting workflow added.