### PR TITLE
hack,content: Support overriding container engine in linting script

### DIFF
--- a/content/en/docs/contribution-guidelines/local-docs.md
+++ b/content/en/docs/contribution-guidelines/local-docs.md
@@ -34,17 +34,23 @@ Any changes will be included in real time.
 
 ## Running the Linting Script Locally
 
-The ./hack/ci/link-check.sh script is responsible for building the site and running [html-proofer](https://github.com/gjtorikian/html-proofer) that validates the generated HTML output.
+The `hack/ci/link-check.sh` script is responsible for building the site and running [html-proofer](https://github.com/gjtorikian/html-proofer) that validates the generated HTML output.
 
-In order to run the linting script locally, run the following command from the root directory:
+Before running the linting script, ensure you have the correct environment variable sets locally:
 
-```sh
+- `$CONTAINER_ENGINE`: controls what container engine will be used. Defaults to `docker`.
+- `$CONTAINER_RUN_EXTRA_OPTIONS`: allows you to specify any additional run options to the container engine. Defaults to an empty string.
+
+In order to run the linting script locally using `podman`, run the following command from the root directory:
+
+```bash
+export CONTAINER_ENGINE="podman"
 ${PWD}/hack/ci/link-check.sh
 ```
 
 **Note**: In the case you're getting permission denied errors when reading from that mounted volume, set the following environment variable and re-run the linting script:
 
-```sh
+```bash
 export CONTAINER_RUN_EXTRA_OPTIONS="--security-opt label=disable"
-./hack/ci/link-check.sh
+${PWD}/hack/ci/link-check.sh
 ```

--- a/hack/ci/link-check.sh
+++ b/hack/ci/link-check.sh
@@ -2,8 +2,10 @@
 set -ev
 
 CONTAINER_RUN_EXTRA_OPTIONS=${CONTAINER_RUN_EXTRA_OPTIONS:=""}
+CONTAINER_ENGINE=${CONTAINER_ENGINE:="docker"}
 
-docker volume create olm-html
-docker run --rm ${CONTAINER_RUN_EXTRA_OPTIONS} -v "$(pwd):/src" -v olm-html:/src/public klakegg/hugo:0.73.0-ext-ubuntu
-docker run --rm -v olm-html:/target mtlynch/htmlproofer /target --empty-alt-ignore --http-status-ignore 429 --allow_hash_href
-docker volume rm olm-html
+# TODO(tflannag): We may need to trap that `... volume rm` call.
+${CONTAINER_ENGINE} volume create olm-html
+${CONTAINER_ENGINE} run --rm ${CONTAINER_RUN_EXTRA_OPTIONS} -v "$(pwd):/src" -v olm-html:/src/public klakegg/hugo:0.73.0-ext-ubuntu
+${CONTAINER_ENGINE} run --rm -v olm-html:/target mtlynch/htmlproofer /target --empty-alt-ignore --http-status-ignore 429 --allow_hash_href
+${CONTAINER_ENGINE} volume rm olm-html

--- a/hack/ci/link-check.sh
+++ b/hack/ci/link-check.sh
@@ -3,9 +3,15 @@ set -ev
 
 CONTAINER_RUN_EXTRA_OPTIONS=${CONTAINER_RUN_EXTRA_OPTIONS:=""}
 CONTAINER_ENGINE=${CONTAINER_ENGINE:="docker"}
+volume_name="olm-html"
 
-# TODO(tflannag): We may need to trap that `... volume rm` call.
-${CONTAINER_ENGINE} volume create olm-html
-${CONTAINER_ENGINE} run --rm ${CONTAINER_RUN_EXTRA_OPTIONS} -v "$(pwd):/src" -v olm-html:/src/public klakegg/hugo:0.73.0-ext-ubuntu
-${CONTAINER_ENGINE} run --rm -v olm-html:/target mtlynch/htmlproofer /target --empty-alt-ignore --http-status-ignore 429 --allow_hash_href
-${CONTAINER_ENGINE} volume rm olm-html
+function cleanup() {
+    exit_status=$?
+    ${CONTAINER_ENGINE} volume rm ${volume_name}
+    exit $exit_status
+}
+trap cleanup EXIT
+
+${CONTAINER_ENGINE} volume create ${volume_name}
+${CONTAINER_ENGINE} run --rm ${CONTAINER_RUN_EXTRA_OPTIONS} -v "$(pwd):/src" -v ${volume_name}:/src/public klakegg/hugo:0.73.0-ext-ubuntu
+${CONTAINER_ENGINE} run --rm -v ${volume_name}:/target mtlynch/htmlproofer /target --empty-alt-ignore --http-status-ignore 429 --allow_hash_href


### PR DESCRIPTION
hack/ci: Support overriding the default container engine (docker) with podman
using the `$CONTAINER_ENGINE` environment variable.

content: Update the `local-docs.md` documentation and document how you may
override the default container engine (docker) to using podman.
