### PR TITLE
Clarify use of version numbers in channel names

### DIFF
--- a/content/en/docs/best-practices/channel-naming.md
+++ b/content/en/docs/best-practices/channel-naming.md
@@ -111,9 +111,9 @@ The names you choose are notional and up to you to decide, however, picking good
 * Channel names are chosen by operator authors as they see fit to meet their upgrade strategies.
 * Channel names are unique to your operator and do not collide with channel names used by other operator providers.
 * Seldom is there a situation where your channel names need to contain information about the Kubernetes or Openshift cluster version they run on.  Only in the case where your operator versions have a dependency on the Kubernetes/Openshift version would you include the cluster version in your channel name.
-* You typically would not include product names in your channels since the channels are unique to your product and will not collide with other channel names used by other operators. 
+* You typically would not include product names in your channels since the channels are unique to your product and will not collide with other channel names used by other operators.
 * You could include or have an operand version in your channel name to advertise to consumers the version of operand they can subscribe to.
-* If you do choose to include some version in your channel name, it is important to include an additional identifier, to clarify what that the version number is referring to. A version number could equally be referring to product version (operand version), or operator version - these two don't always match: the operator itself can have different versioning than the product it is managing). 
+* If you do choose to include some version in your channel name, it is important to include an additional identifier, to clarify what that the version number is referring to. A version number could equally be referring to product version (operand version), or operator version - these two don't always match: the operator itself can have different versioning than the product it is managing. 
 
 
 ### Recommended Channel Naming

--- a/content/en/docs/best-practices/channel-naming.md
+++ b/content/en/docs/best-practices/channel-naming.md
@@ -106,13 +106,14 @@ Channel names are used to imply what form of upgrade you want to offer for your 
 
 The names you choose are notional and up to you to decide, however, picking good channel names requires some basic guidance.  What is described below are different channel naming conventions that are commonly used by the operator community to denote different operator upgrade use cases.
 
-### Naming Convention Rules
+### Naming Conventions
 
 * Channel names are chosen by operator authors as they see fit to meet their upgrade strategies.
 * Channel names are unique to your operator and do not collide with channel names used by other operator providers.
 * Seldom is there a situation where your channel names need to contain information about the Kubernetes or Openshift cluster version they run on.  Only in the case where your operator versions have a dependency on the Kubernetes/Openshift version would you include the cluster version in your channel name.
-* You typically would not include product names in your channels since the channels are unique to your product and will not collide with other channel names used by other operators.
+* You typically would not include product names in your channels since the channels are unique to your product and will not collide with other channel names used by other operators. 
 * You could include or have an operand version in your channel name to advertise to consumers the version of operand they can subscribe to.
+* If you do choose to include some version in your channel name, it is important to include an additional identifier, to clarify what that the version number is referring to. A version number could equally be referring to product version (operand version), or operator version - these two don't always match: the operator itself can have different versioning than the product it is managing). 
 
 
 ### Recommended Channel Naming


### PR DESCRIPTION
Version numbers, on their own, are ambiguous and could be referring to either product or operator version itself.

If I am creating a Subscription to channel `1.x` of `3scale-operator` (note: /not/ of `3scale` - the product), is it really clear that this version is referring to the version of `3scale` (the product) and not to the version of `3scale-operator` (the component)?

As far as I understand when reading these Naming conventions, the intent is for the former (i.e. that the version refers to the product), but does it hurt us to be explicit - by including the product name - and avoid any confusion at all around this?

The problem is that:
a. "3scale operator" is a component that has different versioning than "3scale" (the product). For 3scale 2.10, 3scale operator has version 1.13.0
b. As such, even if the channel is always used within the context of a Subscription, I can never be sure if the version is the version of the operator, or the product (because the subscription is to the operator, not the product).

The screenshot from step 2, but also the Subscription YAML both, hopefully, help illustrate the problem I am referring to. 

If "threescale-" was not included in the channel name and only "2.9" was, how could I know that "2.9" is referring to 3scale (the product) when I am subscribing to **the operator** ?

## Operator Installation - OpenShift Console

### Step 1: Pick operator

![operatorInstallation1](https://user-images.githubusercontent.com/2420882/112905034-71c2a880-90f2-11eb-9b8d-561e0cf6d7c5.png)


### Step 2: Select channel

![operatorInstallation2](https://user-images.githubusercontent.com/2420882/112905006-6b343100-90f2-11eb-9b9c-a2fe126c40d7.png)

### Step 3: View Subscription

![operatorInstallation3](https://user-images.githubusercontent.com/2420882/112904957-61aac900-90f2-11eb-9d75-b1621c34b795.png)



## Alternate installation step : Subscription installation through YAML 

This is what the customer who chooses to install the 3scale operator by applying YAML to their openshift cluster will see.

![operatorInstallation4](https://user-images.githubusercontent.com/2420882/112904915-55267080-90f2-11eb-9b9b-d7009ce571ae.png)

https://github.com/gsaslis/3scale-deployment/blob/main/operators/3scale/3scale-operator-subscription.yaml#L7-L9
