### PR TITLE
content: Fix unrendered/broken links

### DIFF
--- a/content/en/docs/Tasks/install-operator-with-olm.md
+++ b/content/en/docs/Tasks/install-operator-with-olm.md
@@ -6,7 +6,7 @@ description: >
     Install your operator from a catalog of operators
 ---
 
-[Once you have a catalog of operators loaded onto the cluster via a `CatalogSource`] [create-catsrc-doc], you can install your operator by creating a [`Subscription`][subscription-doc] to a specific [channel](channel-def).
+[Once you have a catalog of operators loaded onto the cluster via a `CatalogSource`][create-catsrc-doc], you can install your operator by creating a [`Subscription`][subscription-doc] to a specific [channel][channel-def].
 
 ## Prerequisites
 
@@ -138,4 +138,4 @@ If your intent is to pin an installed Operator to the particular version `1.1.0`
 
 [create-catsrc-doc]: /docs/tasks/make-index-available-on-cluster
 [subscription-doc]: /docs/concepts/crds/subscription
-[channel-def]: /docs/glossary/_index#channel
+[channel-def]: /docs/glossary/#channel


### PR DESCRIPTION
- The `[Once you have a catalog of operators loaded onto the cluster via a `CatalogSource`] [create-catsrc-doc]` had a space in between, which resulted in the link not rendering correctly.
- A recent PR updated the location of the channel-def reference to a link that doesn't exist. That was surfacing in the lint job in the following output:

```
c02a5f3da18c: Pull complete
Digest: sha256:505df5f98139b81fd3563b385134c5a784b58bfc8d5a4ece57fa2cbe58b3144f
Status: Downloaded newer image for mtlynch/htmlproofer:latest
Running ["ImageCheck", "ScriptCheck", "LinkCheck"] on ["/target"] on *.html...

Checking 141 external links...
- /target/docs/tasks/install-operator-with-olm/index.html
  *  internally linking to channel-def, which does not exist (line 678)
     <a href="channel-def">channel</a>
Ran on 44 files
```