### PR TITLE
clarify the customresourcedefinitions example

### DIFF
--- a/content/en/docs/Concepts/crds/clusterserviceversion.md
+++ b/content/en/docs/Concepts/crds/clusterserviceversion.md
@@ -92,15 +92,18 @@ spec:
   customresourcedefinitions:
     owned:
     # a list of CRDs that this operator owns
-    # name is the metadata.name of the CRD
-    - name: cache.example.com
+    # name is the metadata.name of the CRD (which is of the form <plural>.<group>)
+    # version is the spec.versions[].name value defined in the CRD
+    # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
+    - name: memcacheds.cache.example.com
       # version is the version of the CRD (one per entry)
       version: v1alpha1
       # spec.names.kind from the CRD
       kind: Memcached
     required:
     # a list of CRDs that this operator requires
-    - name: other.example.com
+    # see field descriptions above
+    - name: others.example.com
       version: v1alpha1
       kind: Other
 ```

--- a/content/en/docs/Concepts/crds/clusterserviceversion.md
+++ b/content/en/docs/Concepts/crds/clusterserviceversion.md
@@ -93,12 +93,10 @@ spec:
     owned:
     # a list of CRDs that this operator owns
     # name is the metadata.name of the CRD (which is of the form <plural>.<group>)
-    # version is the spec.versions[].name value defined in the CRD
-    # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
     - name: memcacheds.cache.example.com
-      # version is the version of the CRD (one per entry)
+      # version is the spec.versions[].name value defined in the CRD
       version: v1alpha1
-      # spec.names.kind from the CRD
+      # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
       kind: Memcached
     required:
     # a list of CRDs that this operator requires

--- a/content/en/docs/Tasks/creating-operator-manifests.md
+++ b/content/en/docs/Tasks/creating-operator-manifests.md
@@ -164,12 +164,10 @@ spec:
     owned:
     # a list of CRDs that this operator owns
     # name is the metadata.name of the CRD (which is of the form <plural>.<group>)
-    # version is the spec.versions[].name value defined in the CRD
-    # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
     - name: memcacheds.cache.example.com
-      # version is the version of the CRD (one per entry)
+      # version is the spec.versions[].name value defined in the CRD
       version: v1alpha1
-      # spec.names.kind from the CRD
+      # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
       kind: Memcached
 ```
 
@@ -188,10 +186,10 @@ spec:
     required:
     # a list of CRDs that this operator requires
     # name is the metadata.name of the CRD (which is of the form <plural>.<group>)
-    # version is the spec.versions[].name value defined in the CRD
-    # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
     - name: others.example.com
+      # version is the spec.versions[].name value defined in the CRD
       version: v1alpha1
+      # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
       kind: Other
 ```
 
@@ -208,12 +206,10 @@ spec:
     owned:
     # a list of CRDs that this operator owns
     # name is the metadata.name of the CRD (which is of the form <plural>.<group>)
-    # version is the spec.versions[].name value defined in the CRD
-    # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
     - name: memcacheds.cache.example.com
-      # version is the version of the CRD (one per entry)
+      # version is the spec.versions[].name value defined in the CRD
       version: v1alpha1
-      # spec.names.kind from the CRD
+      # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
       kind: Memcached
 ```
 

--- a/content/en/docs/Tasks/creating-operator-manifests.md
+++ b/content/en/docs/Tasks/creating-operator-manifests.md
@@ -163,8 +163,10 @@ spec:
   customresourcedefinitions:
     owned:
     # a list of CRDs that this operator owns
-      # name is the metadata.name of the CRD
-    - name: cache.example.com
+    # name is the metadata.name of the CRD (which is of the form <plural>.<group>)
+    # version is the spec.versions[].name value defined in the CRD
+    # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
+    - name: memcacheds.cache.example.com
       # version is the version of the CRD (one per entry)
       version: v1alpha1
       # spec.names.kind from the CRD
@@ -185,9 +187,12 @@ spec:
   customresourcedefinitions:
     required:
     # a list of CRDs that this operator requires
-    - name: cache.example.com
+    # name is the metadata.name of the CRD (which is of the form <plural>.<group>)
+    # version is the spec.versions[].name value defined in the CRD
+    # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
+    - name: others.example.com
       version: v1alpha1
-      kind: Memcached
+      kind: Other
 ```
 
 Dependency resolution and ownership is discussed more in depth in the [here][dependency-resolution-doc].
@@ -202,8 +207,10 @@ spec:
   customresourcedefinitions:
     owned:
     # a list of CRDs that this operator owns
-      # name is the metadata.name of the CRD
-    - name: cache.example.com
+    # name is the metadata.name of the CRD (which is of the form <plural>.<group>)
+    # version is the spec.versions[].name value defined in the CRD
+    # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
+    - name: memcacheds.cache.example.com
       # version is the version of the CRD (one per entry)
       version: v1alpha1
       # spec.names.kind from the CRD


### PR DESCRIPTION
- example name was misleading  (should be `<plural>.<group>`)
- added clarification for where the values for each field should come from