### PR TITLE
content: Add link to the Docsy docs in the contribution guidelines

### DIFF
--- a/content/en/docs/contribution-guidelines/_index.md
+++ b/content/en/docs/contribution-guidelines/_index.md
@@ -59,8 +59,7 @@ git clone --recurse-submodules --depth 1 https://github.com/google/docsy-example
 ```
 
 1. Run `hugo server` in the site root directory. By default your site will be available at http://localhost:1313. Now that you're serving your site locally, Hugo will watch for changes to the content and automatically refresh your site.
-1. Continue with the usual GitHub workflow to edit files, commit them, push the
-  changes up to your fork, and create a pull request.
+1. Continue with the usual GitHub workflow to edit files, commit them, push the changes up to your fork, and create a pull request.
 
 ## Creating an issue
 
@@ -68,5 +67,5 @@ If you've found a problem in the docs, but you're not sure how to fix it yoursel
 
 ## Useful resources
 
-* [Docsy user guide](wherever it goes): All about Docsy, including how it manages navigation, look and feel, and multi-language support.
+* [Docsy user guide](https://www.docsy.dev/docs/): All about Docsy, including how it manages navigation, look and feel, and multi-language support.
 * [Hugo documentation](https://gohugo.io/documentation/): Comprehensive reference for Hugo.

--- a/content/en/docs/contribution-guidelines/_index.md
+++ b/content/en/docs/contribution-guidelines/_index.md
@@ -24,42 +24,42 @@ Here's a quick guide to updating the docs. It assumes you're familiar with the
 GitHub workflow and you're happy to use the automated preview of your doc
 updates:
 
-1. Fork [olm-docs](https://github.com/operator-framework/olm-docs) on GitHub.
-1. Make your changes and send a pull request (PR).
-1. If you're not yet ready for a review, add "WIP" to the PR name to indicate
+- Fork [olm-docs](https://github.com/operator-framework/olm-docs) on GitHub.
+- Make your changes and send a pull request (PR).
+- If you're not yet ready for a review, add "WIP" to the PR name to indicate
   it's a work in progress. (**Don't** add the Hugo property
   "draft = true" to the page front matter, because that prevents the
   auto-deployment of the content preview described in the next point.)
-1. Wait for the automated PR workflow to do some checks. When it's ready,
+- Wait for the automated PR workflow to do some checks. When it's ready,
   you should see a comment like this: **deploy/netlify — Deploy preview ready!**
-1. Click **Details** to the right of "Deploy preview ready" to see a preview
+- Click **Details** to the right of "Deploy preview ready" to see a preview
   of your updates.
-1. Continue updating your doc and pushing your changes until you're happy with
+- Continue updating your doc and pushing your changes until you're happy with
   the content.
-1. When you're ready for a review, add a comment to the PR, and remove any
+- When you're ready for a review, add a comment to the PR, and remove any
   "WIP" markers.
 
 ## Updating a single page
 
 If you've just spotted something you'd like to change while using the docs, Docsy has a shortcut for you:
 
-1. Click **Edit this page** in the top right hand corner of the page.
-1. If you don't already have an up to date fork of the project repo, you are prompted to get one - click **Fork this repository and propose changes** or **Update your Fork** to get an up to date version of the project to edit. The appropriate page in your fork is displayed in edit mode.
-1. Follow the rest of the [Quick start with Netlify](#quick-start-with-netlify) process above to make, preview, and propose your changes.
+- Click **Edit this page** in the top right hand corner of the page.
+- If you don't already have an up to date fork of the project repo, you are prompted to get one - click **Fork this repository and propose changes** or **Update your Fork** to get an up to date version of the project to edit. The appropriate page in your fork is displayed in edit mode.
+- Follow the rest of the [Quick start with Netlify](#quick-start-with-netlify) process above to make, preview, and propose your changes.
 
 ## Previewing your changes locally
 
 If you want to run your own local Hugo server to preview your changes as you work:
 
-1. Follow the instructions in [Getting started](/docs/getting-started) to install Hugo and any other tools you need. You'll need at least **Hugo version 0.45** (we recommend using the most recent available version), and it must be the **extended** version, which supports SCSS.
-1. Fork [olm-docs](https://github.com/operator-framework/olm-docs), then create a local copy using `git clone`. Don’t forget to use `--recurse-submodules` or you won’t pull down some of the code you need to generate a working site.
+- Follow the instructions in [Getting started](/docs/getting-started) to install Hugo and any other tools you need. You'll need at least **Hugo version 0.45** (we recommend using the most recent available version), and it must be the **extended** version, which supports SCSS.
+- Fork [olm-docs](https://github.com/operator-framework/olm-docs), then create a local copy using `git clone`. Don’t forget to use `--recurse-submodules` or you won’t pull down some of the code you need to generate a working site.
 
 ```bash
 git clone --recurse-submodules --depth 1 https://github.com/google/docsy-example.git
 ```
 
-1. Run `hugo server` in the site root directory. By default your site will be available at http://localhost:1313. Now that you're serving your site locally, Hugo will watch for changes to the content and automatically refresh your site.
-1. Continue with the usual GitHub workflow to edit files, commit them, push the changes up to your fork, and create a pull request.
+- Run `hugo server` in the site root directory. By default your site will be available at http://localhost:1313. Now that you're serving your site locally, Hugo will watch for changes to the content and automatically refresh your site.
+- Continue with the usual GitHub workflow to edit files, commit them, push the changes up to your fork, and create a pull request.
 
 ## Creating an issue
 
@@ -67,5 +67,5 @@ If you've found a problem in the docs, but you're not sure how to fix it yoursel
 
 ## Useful resources
 
-* [Docsy user guide](https://www.docsy.dev/docs/): All about Docsy, including how it manages navigation, look and feel, and multi-language support.
-* [Hugo documentation](https://gohugo.io/documentation/): Comprehensive reference for Hugo.
+- [Docsy user guide](https://www.docsy.dev/docs/): All about Docsy, including how it manages navigation, look and feel, and multi-language support.
+- [Hugo documentation](https://gohugo.io/documentation/): Comprehensive reference for Hugo.


### PR DESCRIPTION
Update the contribution guidelines and add a link to the Docsy
documentation instead of the broken `[Docsy user guide](wherever it goes)`
reference that's currently being deployed.