### PR TITLE
cleanup: rename `subscription.spec.approval` to `subscription.spec.installPlanApproval`

### DIFF
--- a/content/en/docs/Concepts/operators-on-cluster.md
+++ b/content/en/docs/Concepts/operators-on-cluster.md
@@ -41,7 +41,7 @@ spec:
   name: my-operator
   source: my-catalog
   sourceNamespace: olm
-  approval: Manual
+  installPlanApproval: Manual
 
 $ kubectl apply -f sub.yaml
 subscription.operators.coreos.com/sub-to-my-operator created

--- a/content/en/docs/Tasks/install-operator-with-olm.md
+++ b/content/en/docs/Tasks/install-operator-with-olm.md
@@ -77,13 +77,13 @@ spec:
   name: my-operator
   source: my-catalog
   sourceNamespace: olm
-  approval: Manual
+  installPlanApproval: Manual
 
 $ kubectl apply -f sub.yaml
 subscription.operators.coreos.com/sub-to-my-operator created
  ```
 
-Since the `approval` is `Manual`, we need to manually go in and approve the `InstallPlan`
+Since `installPlanApproval` is set to `Manual`, we need to manually go in and approve the `InstallPlan`
 
 ```bash
 $ kubectl get ip -n foo

--- a/content/en/docs/Tasks/uninstall-operator.md
+++ b/content/en/docs/Tasks/uninstall-operator.md
@@ -16,7 +16,7 @@ The cluster admin should first understand which types (CRDs and APIServices) are
 
 ## Step 2: Unsubscribe from the Operator
 
-OLM uses the subscription resource to convey a user's intent to subscribe to the latest version of an operator. If the operator was installed with Automatic Updates (spec.Approval: `Automatic`), OLM will reinstall a new version of the operator even if the operator's CSV was deleted earlier. In effect, you must tell OLM that you do not want new versions of the operator to be installed by deleting the subscription associated with the operator.
+OLM uses the subscription resource to convey a user's intent to subscribe to the latest version of an operator. If the operator was installed with Automatic Updates (spec.InstallPlanApproval: `Automatic`), OLM will reinstall a new version of the operator even if the operator's CSV was deleted earlier. In effect, you must tell OLM that you do not want new versions of the operator to be installed by deleting the subscription associated with the operator.
 
 You can list existing `Subscription` in a specific namespace with the following `kubectl` command:
 


### PR DESCRIPTION

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>