### PR TITLE
content: Fix broken link to the operator capabilities SDK documentation

### DIFF
--- a/content/en/about/_index.html
+++ b/content/en/about/_index.html
@@ -77,7 +77,7 @@ menu:
         <h2 class="of-heading of-heading--xl">LEVEL UP YOUR OPERATOR</h2>
         <p class="of-section--largetext__content">Learn about operator maturity and the requirements to approach full auto
           pilot.</p>
-        <a href="https://sdk.operatorframework.io/docs/advanced-topics/operator-capabilities/operator-capabilities" class="of-button of-button--tertiary">Learn More
+        <a href="https://sdk.operatorframework.io/docs/overview/operator-capabilities/" class="of-button of-button--tertiary">Learn More
           <svg class="of-button__icon" enable-background="new 0 0 22 22" version="1.1" viewBox="0 0 22 22"
             xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
             <path


### PR DESCRIPTION
Update the operator capabilities link in the _index.html. This path to
this link was changed in
https://github.com/operator-framework/operator-sdk/commit/60bfe2eb0aedd1ce9b55bb6ddbaebba7d972b4ef#diff-b49ecbfece1c78775e4b1bf5db7420ea14dd59d9baf81ef3903e1a8bd227ebec.