### PR TITLE
.github/workflows: Update the lint workflow to checkout the correct commit

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Checkout submodules
       run: git submodule update --init --recursive


### PR DESCRIPTION
Update the .github/workflows/lint.yaml check and ensure that the
actions/checkout@v2 step is checking out the correct commit.

It looks like there's an existing bug in the actions/checkout@v2 action
such that it's pointing to the wrong commit hash when checking out the
repository. This can lead to cases where an action job may fail in a PR,
another PR fixes that action, and the first PR still fails as it's
checking out the wrong commit hash. Temporary workarounds include
rebasing the first PR to pick up the new changes, but this can lead to
larger situations where we're not accurately testing changes against an
upstream/master remote.