### PR TITLE
.github/workflow: Remove unneeded submodule checkout step

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,9 +7,8 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
-
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      with:
+        submodules: recursive
 
     - name: Run linting script
       run: ${PWD}/hack/ci/link-check.sh


### PR DESCRIPTION
The actions/checkout@v2 has an option to recursively checking out
submodules, so the manual step of checking out the submodules after
checking out the repository is not needed.