### PR TITLE
Add redirection from latest to v0.18.z

### DIFF
--- a/content/en/docs/Concepts/olm-architecture/operator-catalog/creating-an-update-graph.md
+++ b/content/en/docs/Concepts/olm-architecture/operator-catalog/creating-an-update-graph.md
@@ -6,6 +6,8 @@ description: >
     Creating an update graph with OLM
 ---
 
+>Note: This document discusses creating an upgrade graph for your operator using plaintext files to store catalog metadata, which is the [latest feature][[file-based-catalog-spec]] of OLM catalogs. If you are looking to create an upgrade graph for your operator using the deprecated sqllite database format to store catalog metadata instead, please read the [v0.18.z version][v0.18.z-version] of this doc instead.
+
 # Creating an Update Graph
 
 OLM provides a variety of ways to specify updates between operator versions.
@@ -255,3 +257,4 @@ entries:
 
 [file-based-catalog-spec]: /docs/reference/file-based-catalogs
 [opm-validate-cli]: /docs/reference/file-based-catalogs/#opm-validate
+[v0.18.z-version]:  https://v0-18-z.olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/

--- a/content/en/docs/Tasks/creating-a-catalog.md
+++ b/content/en/docs/Tasks/creating-a-catalog.md
@@ -9,6 +9,7 @@ description: >
 
 - [opm](https://github.com/operator-framework/operator-registry/releases) `v1.19.0+`
 
+>Note: This document discusses creating a catalog of operators using plaintext files to store catalog metadata, which is the [latest feature][file-based-catalog-spec] of OLM catalogs. If you are looking to build catalogs using the deprecated sqllite database format to store catalog metadata instead, please read the [v0.18.z version][v0.18.z-version] of this doc instead. 
 ## Creating a Catalog
 
 `OLM`'s `CatalogSource` [CRD][catalogsource-crd] accepts a container image reference to a catalog of operators that can
@@ -128,3 +129,4 @@ Now the catalog image is available for clusters to use and reference with `Catal
 [catalogsource-crd]: /docs/concepts/crds/catalogsource
 [file-based-catalog-spec]: /docs/reference/file-based-catalogs
 [upgrade-graph-doc]: /docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph
+[v0.18.z-version]:  https://v0-18-z.olm.operatorframework.io/docs/tasks/make-index-available-on-cluster/

--- a/content/en/docs/Tasks/creating-a-catalog.md
+++ b/content/en/docs/Tasks/creating-a-catalog.md
@@ -95,7 +95,7 @@ In the general case, adding a bundle involves three discreet steps:
 
 > NOTE: catalog metadata should be stored in a version control system (e.g. `git`) and catalog images should be rebuilt from source
 whenever updates are made to ensure that all changes to the catalog are auditable. Here is an example of catalog metadata being stored 
-in github: https://github.com/operator-framework/cool-catalog, with the catalog image being rebuilt whenever there is a change: 
+in github: https://github.com/operator-framework/cool-catalog , with the catalog image being rebuilt whenever there is a change: 
 https://github.com/operator-framework/cool-catalog/blob/main/.github/workflows/build-push.yml
 
 **Step 1** is just a simple `opm render` command.

--- a/content/en/docs/Tasks/make-catalog-available-on-cluster.md
+++ b/content/en/docs/Tasks/make-catalog-available-on-cluster.md
@@ -47,7 +47,7 @@ cool-catalog-dtqv2     1/1    Running      0       30s
 
 It is possible to configure the `CatalogSource` to poll a source, such as an image registry, to check whether the catalog source pod should be updated. A common use case would be pushing new bundles to the same catalog source tag, and seeing updated operators from those bundles being installed in the cluster. 
 
-For example, say currently you have Operator X v1.0 installed in the cluster from the catalog `quay.io/my-namespace/cool-catalog:main`. This is the latest version of the X operator in the catalog. When a new v2.0 of Operator X is published, the v2.0 version of the X operator can be included in the catalog using the same steps described in the [creating catalog doc](creating-a-catalog-summary), then the catalog image can be rebuilt and pushed to the same `main` tag. With catalog polling enabled, OLM will pull down the newer version of the catalog image and make the new information available. 
+For example, say currently you have Operator X v1.0 installed in the cluster from the catalog `quay.io/my-namespace/cool-catalog:main`. This is the latest version of the X operator in the catalog. When a new v2.0 of Operator X is published, the v2.0 version of the X operator can be included in the catalog using the same steps described in the [creating catalog doc][creating-a-catalog-summary], then the catalog image can be rebuilt and pushed to the same `main` tag. With catalog polling enabled, OLM will pull down the newer version of the catalog image and make the new information available. 
 
 Each type of check for an updated catalog source is called an `updateStrategy`. Only one `updateStrategy` is supported at a time. `registryPoll` is a type of `updateStrategy` that checks an image registry for an updated version of the same tag(via image SHAs). The `interval` defines the amount of time between each successive poll.
 
@@ -85,4 +85,4 @@ spec:
       interval: 10m
 ```
 
-[creating-a-catalog-summary]: /docs/tasks/creating-a-catalog#summary
+[creating-a-catalog-summary]: /docs/tasks/creating-a-catalog/#summary


### PR DESCRIPTION
This PR redirects current users of sqllite backed catalogs to the v0.18.z
version of the docs that have behaviour changes from sqllite backed catalogs
to plaintext file backed catalogs.

A follow up PR will discuss the steps for migrating existing sqllite backed
catalogs to plaintext file backed catalogs in a new doc.