### PR TITLE
(fix): yq usage in troubleshooting docs

### DIFF
--- a/content/en/docs/Reference/file-based-catalogs.md
+++ b/content/en/docs/Reference/file-based-catalogs.md
@@ -574,7 +574,7 @@ There are many possible ways to build a catalog, but an extremely simple approac
    docker build -t "$indexImage" -f "$name.Dockerfile" .
    docker push "$indexImage"
    ```
-
+>Note: The `yq` binary used in the script can be found [here](https://github.com/mikefarah/yq)
 ## Automation
 
 Operator authors and catalog maintainers are encouraged to automate their catalog maintenance with CI/CD workflows.

--- a/content/en/docs/Tasks/Troubleshooting/catalogsource.md
+++ b/content/en/docs/Tasks/Troubleshooting/catalogsource.md
@@ -7,11 +7,14 @@ description: >
   Tips and tricks related to troubleshooting the configuration of a `CatalogSource`.
 ---
 
+## Prerequisites 
+
+- [yq](https://github.com/mikefarah/yq)
 ## How to debug a failing CatalogSource
 
 The [Catalog operator][olm-arch-doc] will constantly update the `Status` of `CatalogSources` to reflect its current state. You can check the `Status` of your `CatalogSource` with the following command:
 
-`$ kubectl -n my-namespace get catsrc my-catalog -o yaml | yq r - status`
+`$ kubectl get catsrc my-catalog -n <namespace> -o yaml | yq e '.status' -`
 
 >Note: It is possible that the `Status` is missing, which suggests that the Catalog operator is encountering an issue when processing the `CatalogSource` in a very early stage.
 

--- a/content/en/docs/Tasks/Troubleshooting/clusterserviceversion.md
+++ b/content/en/docs/Tasks/Troubleshooting/clusterserviceversion.md
@@ -7,11 +7,16 @@ description: >
   Tips and tricks related to troubleshooting a `ClusterServiceVersion`.
 ---
 
+
+## Prerequisites 
+
+- [yq](https://github.com/mikefarah/yq)
+
 ### How to debug a failing CSV
 
 If the OLM operator encounters an unrecoverable error when attempting to install the operator, the `CSV` will be placed in the `failed` phase. The OLM operator will constantly update the `Status` with useful information regarding the state of the `CSV`. You can check the `Status` of your `CSV` with the following command:
 
-`$ kubectl -n my-catalogsource-namespace get csv prometheusoperator.0.32.0 -o yaml | yq r - status`
+`$ kubectl get csv prometheusoperator.0.32.0 -n <namespace> -o yaml | yq e '.status' -`
 
 >Note: It is possible that the Status is missing, which suggests that the OLM operator is encountering an issue when processing the `CSV` in a very early stage. You should respond by reviewing the logs of the OLM operator.
 

--- a/content/en/docs/Tasks/Troubleshooting/subscription.md
+++ b/content/en/docs/Tasks/Troubleshooting/subscription.md
@@ -11,11 +11,15 @@ description: >
 This section assumes that you have a working `CatalogSource`. Please see how to [troubleshoot a CatalogSource](/docs/tasks/troubleshooting/catalogsource/) if you're having trouble configuring a CatalogSource.
 {{% /pageinfo %}}
 
+## Prerequisites 
+
+- [yq](https://github.com/mikefarah/yq)
+
 ### How to debug a failing Subscription
 
 The Catalog operator will constantly update the `Status` of `Subscription` to reflect its current state. You can check the `Status` of your `Subscription` with the following command:
 
-`$ kubectl -n my-namespace get subscriptions my-subscription -o yaml | yq r - status`
+`$ kubectl get subscription <subscription-name> -n <namespace> -o yaml | yq e '.status' -`
 
 >Note: It is possible that the `Status` is missing, which suggests that the Catalog operator is encountering an issue when processing the `Subscription` in a very early stage.
 


### PR DESCRIPTION
This PR fixes part of the instructions to troubleshoot failing
resources using yq.