### PR TITLE
content: Fix invalid link syntax in creating-an-upgrade-graph.md

### DIFF
--- a/content/en/docs/Concepts/olm-architecture/operator-catalog/creating-an-update-graph.md
+++ b/content/en/docs/Concepts/olm-architecture/operator-catalog/creating-an-update-graph.md
@@ -6,7 +6,7 @@ description: >
     Creating an update graph with OLM
 ---
 
->Note: This document discusses creating an upgrade graph for your operator using plaintext files to store catalog metadata, which is the [latest feature][[file-based-catalog-spec]] of OLM catalogs. If you are looking to create an upgrade graph for your operator using the deprecated sqllite database format to store catalog metadata instead, please read the [v0.18.z version][v0.18.z-version] of this doc instead.
+>Note: This document discusses creating an upgrade graph for your operator using plaintext files to store catalog metadata, which is the [latest feature][file-based-catalog-spec] of OLM catalogs. If you are looking to create an upgrade graph for your operator using the deprecated sqllite database format to store catalog metadata instead, please read the [v0.18.z version][v0.18.z-version] of this doc instead.
 
 # Creating an Update Graph
 


### PR DESCRIPTION
Update the creating-an-update-graph.md documentation and fix the link
syntax when referencing file-based catalogs.

Signed-off-by: timflannagan <timflannagan@gmail.com>