### PR TITLE
Fix field name typo in skipRange example

### DIFF
--- a/content/en/docs/Concepts/olm-architecture/operator-catalog/creating-an-update-graph.md
+++ b/content/en/docs/Concepts/olm-architecture/operator-catalog/creating-an-update-graph.md
@@ -88,7 +88,7 @@ Internally, OLM uses the [blang/semver](https://github.com/blang/semver) go libr
 ---
 schema: olm.channel
 package: myoperator
-channel: stable
+name: stable
 entries:
   - name: myoperator.v1.0.3
     skipRange: ">=1.0.0 <1.0.3"


### PR DESCRIPTION
Looks like a typo -- `olm.channel`'s schema does not have a `channel` field and instead uses `name`