### PR TITLE
(chore) Remove RedHat links

### DIFF
--- a/themes/docsy/layouts/partials/footer.html
+++ b/themes/docsy/layouts/partials/footer.html
@@ -23,8 +23,6 @@
       document.write(new Date().getFullYear());
     </script></p>
     <ul class="of-link-list">
-      <li class="of-link-list__li"><a href="https://www.redhat.com/en/about/privacy-policy">Privacy Statement</a></li>
-      <!-- <li class="of-link-list__li"><a href="/terms/">Terms of Use</a></li> -->
     </ul>
     <a class="of-footer-main__badge" href="https://www.netlify.com">
         <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify">

--- a/themes/docsy/layouts/partials/head.html
+++ b/themes/docsy/layouts/partials/head.html
@@ -1,4 +1,3 @@
-<script id="dpal" src="//www.redhat.com/ma/dpal-staging.js" type="text/javascript"></script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}


### PR DESCRIPTION
This PR removes a RedHat specific script and the RedHat Privacy
statement link from the website.