### PR TITLE
fix: correct OperatorGroup.UpgradeStrategy example

### DIFF
--- a/content/en/docs/advanced-tasks/unsafe-fail-forward-upgrades.md
+++ b/content/en/docs/advanced-tasks/unsafe-fail-forward-upgrades.md
@@ -40,9 +40,8 @@ metadata:
   name: foo
   namespace: bar
 spec:
-  upgradeStrategy:
-     # Possible values include "Default" or "TechPreviewUnsafeFailForward".
-    name: TechPreviewUnsafeFailForward
+  # Possible values include "Default" or "TechPreviewUnsafeFailForward".
+  upgradeStrategy: TechPreviewUnsafeFailForward
 ```
 
 With the upgradeStrategy type set to `TechPreviewUnsafeFailForward`, OLM will allow operators to "UnsafeFailForward" in adherence with the principles discussed below. If the upgradeStrategy is unset or set to `Default` OLM will exhibit existing behavior.


### PR DESCRIPTION
### Summary

Correcting `OperatorGroup.UpgradeStrategy` example to match API definition https://github.com/operator-framework/api/blob/master/pkg/operators/v1/operatorgroup_types.go#L91