### PR TITLE
Use correct table heading for resource owner

### DIFF
--- a/content/en/docs/Concepts/olm-architecture/_index.md
+++ b/content/en/docs/Concepts/olm-architecture/_index.md
@@ -27,8 +27,8 @@ Each of these Operators are also responsible for creating resources:
 
 **_Table 2. Resources created by OLM and Catalog Operator_**
 
-| Resource                           | Short Name  |
-|------------------------------------|-------------|
+| Resource                           | Owner   |
+|------------------------------------|---------|
 | Deployments                        | OLM     |
 | ServiceAccounts                    | OLM     |
 | (Cluster)Roles                     | OLM     |


### PR DESCRIPTION
Use correct column headings of the OLM - & Catalog Operator resource table.