### PR TITLE
Fix typo in uninstall operator task

### DIFF
--- a/content/en/docs/Tasks/uninstall-operator.md
+++ b/content/en/docs/Tasks/uninstall-operator.md
@@ -59,7 +59,7 @@ kubectl delete clusterserviceversion <csv-name> -n <namespace>
 Alternatively, you can delete both `Subscription` and its `CSV` using a sequence of commands:
 
 ```bash
-CSV=kubectl get subscription <subscription-name> -n <namespace> -o json | jq '.status.installedCSV'
+CSV=$(kubectl get subscription <subscription-name> -n <namespace> -o json | jq '.status.installedCSV')
 kubectl delete subscription <subscription-name> -n <namespace>
 kubectl delete csv $CSV -n <namespace>
 ```

--- a/content/en/docs/Tasks/uninstall-operator.md
+++ b/content/en/docs/Tasks/uninstall-operator.md
@@ -59,7 +59,7 @@ kubectl delete clusterserviceversion <csv-name> -n <namespace>
 Alternatively, you can delete both `Subscription` and its `CSV` using a sequence of commands:
 
 ```bash
-CSV=kubectl delete subscription <subscription-name> -n <namespace> -o json | jq '.status.installedCSV'
+CSV=kubectl get subscription <subscription-name> -n <namespace> -o json | jq '.status.installedCSV'
 kubectl delete subscription <subscription-name> -n <namespace>
 kubectl delete csv $CSV -n <namespace>
 ```


### PR DESCRIPTION
The doc was using kubectl delete where I think it should use kubectl get
Also `$()` were missing to assign the result to the environment variable