### PR TITLE
Updates quick start guide

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -15,49 +15,51 @@ description: >
 
 The `operator-sdk` binary provides a command to easily install and uninstall OLM in a Kubernetes cluster. See the [SDK installation guide][sdk-installation-guide] on how to install `operator-sdk` tooling.
 
-Once you have the `operator-sdk` binary installed, you can easily install OLM on your cluster by running `operator-sdk olm install`. 
+After you have the `operator-sdk` binary installed, you can install OLM on your cluster by running `operator-sdk olm install`.
 
-```bash 
-$ operator-sdk olm install 
-INFO[0000] Fetching CRDs for version "latest"           
-INFO[0000] Fetching resources for resolved version "latest" 
-I0428 10:07:00.985939 3850425 request.go:655] Throttling request took 1.046148019s, request: GET:https://127.0.0.1:45457/apis/storage.k8s.io/v1beta1?timeout=32s
-INFO[0008] Creating CRDs and resources                  
-INFO[0008]   Creating CustomResourceDefinition "catalogsources.operators.coreos.com" 
-INFO[0008]   Creating CustomResourceDefinition "clusterserviceversions.operators.coreos.com" 
-INFO[0008]   Creating CustomResourceDefinition "installplans.operators.coreos.com" 
-INFO[0008]   Creating CustomResourceDefinition "operatorconditions.operators.coreos.com" 
-INFO[0008]   Creating CustomResourceDefinition "operatorgroups.operators.coreos.com" 
-INFO[0008]   Creating CustomResourceDefinition "operators.operators.coreos.com" 
-INFO[0008]   Creating CustomResourceDefinition "subscriptions.operators.coreos.com" 
-INFO[0008]   Creating Namespace "olm"                   
-INFO[0008]   Creating Namespace "operators"             
-INFO[0008]   Creating ServiceAccount "olm/olm-operator-serviceaccount" 
-INFO[0008]   Creating ClusterRole "system:controller:operator-lifecycle-manager" 
-INFO[0008]   Creating ClusterRoleBinding "olm-operator-binding-olm" 
-INFO[0008]   Creating Deployment "olm/olm-operator"     
-INFO[0008]   Creating Deployment "olm/catalog-operator" 
-INFO[0008]   Creating ClusterRole "aggregate-olm-edit"  
-INFO[0008]   Creating ClusterRole "aggregate-olm-view"  
-INFO[0008]   Creating OperatorGroup "operators/global-operators" 
-INFO[0010]   Creating OperatorGroup "olm/olm-operators" 
-INFO[0010]   Creating ClusterServiceVersion "olm/packageserver" 
-INFO[0012]   Creating CatalogSource "olm/operatorhubio-catalog" 
-INFO[0012] Waiting for deployment/olm-operator rollout to complete 
-INFO[0012]   Waiting for Deployment "olm/olm-operator" to rollout: 0 of 1 updated replicas are available 
-INFO[0026]   Deployment "olm/olm-operator" successfully rolled out 
-INFO[0026] Waiting for deployment/catalog-operator rollout to complete 
-INFO[0026]   Waiting for Deployment "olm/catalog-operator" to rollout: 0 of 1 updated replicas are available 
-INFO[0031]   Deployment "olm/catalog-operator" successfully rolled out 
-INFO[0031] Waiting for deployment/packageserver rollout to complete 
-INFO[0031]   Waiting for Deployment "olm/packageserver" to rollout: 0 of 2 updated replicas are available 
-INFO[0037]   Deployment "olm/packageserver" successfully rolled out 
-INFO[0037] Successfully installed OLM version "latest"  
+```bash
+$ operator-sdk olm install
+INFO[0000] Fetching CRDs for version "latest"
+INFO[0000] Fetching resources for resolved version "latest"
+I0302 14:26:13.947244   61268 request.go:682] Waited for 1.041225333s due to client-side throttling, not priority and fairness, request: GET:https://127.0.0.1:63693/apis/flowcontrol.apiserver.k8s.io/v1beta2?timeout=32s
+INFO[0006] Creating CRDs and resources
+INFO[0006]   Creating CustomResourceDefinition "catalogsources.operators.coreos.com"
+INFO[0006]   Creating CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
+INFO[0006]   Creating CustomResourceDefinition "installplans.operators.coreos.com"
+INFO[0006]   Creating CustomResourceDefinition "olmconfigs.operators.coreos.com"
+INFO[0006]   Creating CustomResourceDefinition "operatorconditions.operators.coreos.com"
+INFO[0006]   Creating CustomResourceDefinition "operatorgroups.operators.coreos.com"
+INFO[0006]   Creating CustomResourceDefinition "operators.operators.coreos.com"
+INFO[0006]   Creating CustomResourceDefinition "subscriptions.operators.coreos.com"
+INFO[0006]   Creating Namespace "olm"
+INFO[0006]   Creating Namespace "operators"
+INFO[0006]   Creating ServiceAccount "olm/olm-operator-serviceaccount"
+INFO[0006]   Creating ClusterRole "system:controller:operator-lifecycle-manager"
+INFO[0006]   Creating ClusterRoleBinding "olm-operator-binding-olm"
+INFO[0006]   Creating OLMConfig "cluster"
+INFO[0009]   Creating Deployment "olm/olm-operator"
+INFO[0009]   Creating Deployment "olm/catalog-operator"
+INFO[0009]   Creating ClusterRole "aggregate-olm-edit"
+INFO[0009]   Creating ClusterRole "aggregate-olm-view"
+INFO[0009]   Creating OperatorGroup "operators/global-operators"
+INFO[0009]   Creating OperatorGroup "olm/olm-operators"
+INFO[0009]   Creating ClusterServiceVersion "olm/packageserver"
+INFO[0010]   Creating CatalogSource "olm/operatorhubio-catalog"
+INFO[0010] Waiting for deployment/olm-operator rollout to complete
+INFO[0010]   Waiting for Deployment "olm/olm-operator" to rollout: 0 of 1 updated replicas are available
+INFO[0021]   Deployment "olm/olm-operator" successfully rolled out
+INFO[0021] Waiting for deployment/catalog-operator rollout to complete
+INFO[0021]   Deployment "olm/catalog-operator" successfully rolled out
+INFO[0021] Waiting for deployment/packageserver rollout to complete
+INFO[0021]   Waiting for Deployment "olm/packageserver" to rollout: 0 of 2 updated replicas are available
+INFO[0032]   Deployment "olm/packageserver" successfully rolled out
+INFO[0032] Successfully installed OLM version "latest"
 
 NAME                                            NAMESPACE    KIND                        STATUS
 catalogsources.operators.coreos.com                          CustomResourceDefinition    Installed
 clusterserviceversions.operators.coreos.com                  CustomResourceDefinition    Installed
 installplans.operators.coreos.com                            CustomResourceDefinition    Installed
+olmconfigs.operators.coreos.com                              CustomResourceDefinition    Installed
 operatorconditions.operators.coreos.com                      CustomResourceDefinition    Installed
 operatorgroups.operators.coreos.com                          CustomResourceDefinition    Installed
 operators.operators.coreos.com                               CustomResourceDefinition    Installed
@@ -67,6 +69,7 @@ operators                                                    Namespace          
 olm-operator-serviceaccount                     olm          ServiceAccount              Installed
 system:controller:operator-lifecycle-manager                 ClusterRole                 Installed
 olm-operator-binding-olm                                     ClusterRoleBinding          Installed
+cluster                                                      OLMConfig                   Installed
 olm-operator                                    olm          Deployment                  Installed
 catalog-operator                                olm          Deployment                  Installed
 aggregate-olm-edit                                           ClusterRole                 Installed
@@ -75,7 +78,6 @@ global-operators                                operators    OperatorGroup      
 olm-operators                                   olm          OperatorGroup               Installed
 packageserver                                   olm          ClusterServiceVersion       Installed
 operatorhubio-catalog                           olm          CatalogSource               Installed
-
 ```
 
 ## Installing an Operator using OLM
@@ -85,15 +87,15 @@ You can use the `packagemanifest` api to see the operators available for you to 
 
 ```sh
 $ kubectl get packagemanifest -n olm
-NAME                               CATALOG               AGE
-cassandra-operator                 Community Operators   26m
-etcd                               Community Operators   26m
-postgres-operator                  Community Operators   26m
-prometheus                         Community Operators   26m
-wildfly                            Community Operators   26m
+NAME                                       CATALOG               AGE
+# ...
+noobaa-operator                            Community Operators   2m17s
+project-quay                               Community Operators   2m17s
+ack-eks-controller                         Community Operators   2m17s
+# ...
 ```
 
-To install the etcd operator in the default namespace, first create an `OperatorGroup` for the default namespace:
+To install the quay operator in the default namespace, first create an `OperatorGroup` for the default namespace:
 
 ```sh
 $ cat operatorgroup.yaml
@@ -110,41 +112,41 @@ $ kubectl apply -f operatorgroup.yaml
 operatorgroup.operators.coreos.com/og-single created
 ```
 
-Then create a subscription for the etcd operator:
+Then create a subscription for the quay operator:
 
 ```sh
 $ cat subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: etcd
+  name: quay
   namespace: default
 spec:
-  channel: singlenamespace-alpha
+  channel: stable-3.8
   installPlanApproval: Automatic
-  name: etcd
+  name: project-quay
   source: operatorhubio-catalog
   sourceNamespace: olm
-  startingCSV: etcdoperator.v0.9.2
+  startingCSV: quay-operator.v3.8.1
 
 $ kubectl apply -f subscription.yaml
-subscription.operators.coreos.com/etcd created
+subscription.operators.coreos.com/quay created
 ```
 
-This installs the v0.9.2 version of the etcd operator, and then upgrades to the latest version of the etcd operator in your cluster.
+This installs the v3.8.1 version of the quay operator, and then upgrades to the latest version of the quay operator in your cluster.
 
 ```sh
 $ kubectl get sub -n default
-NAME   PACKAGE   SOURCE                  CHANNEL
-etcd   etcd      operatorhubio-catalog   singlenamespace-alpha
+NAME   PACKAGE        SOURCE                  CHANNEL
+quay   project-quay   operatorhubio-catalog   stable-3.8
 
 $ kubectl get csv -n default
-NAME                  DISPLAY   VERSION   REPLACES              PHASE
-etcdoperator.v0.9.4   etcd      0.9.4     etcdoperator.v0.9.2   Succeeded
+NAME                   DISPLAY   VERSION   REPLACES               PHASE
+quay-operator.v3.8.3   Quay      3.8.3     quay-operator.v3.8.1   Succeeded
 
 $ kubectl get deployment -n default
-NAME            READY   UP-TO-DATE   AVAILABLE   AGE
-etcd-operator   1/1     1            1           3m29s
+NAME                READY   UP-TO-DATE   AVAILABLE   AGE
+quay-operator-tng   1/1     1            1           40s
 ```
 
 To learn more about packaging your operator for OLM, installing/uninstalling an operator etc, visit the [Core Tasks](/docs/tasks/) and the [Advanced Tasks](/docs/advanced-tasks/) sections of this site.


### PR DESCRIPTION
etcd operator no longer works with K8s v1.22+ due to a dependency on a removed API.

Related issues:
* https://github.com/operator-framework/olm-docs/issues/241
* https://github.com/operator-framework/olm-docs/issues/268
* https://github.com/operator-framework/operator-lifecycle-manager/issues/2931

Closes #241