### PR TITLE
Fixes table escaping

### DIFF
--- a/content/en/docs/contribution-guidelines/upgrade-graphs.md
+++ b/content/en/docs/contribution-guidelines/upgrade-graphs.md
@@ -192,14 +192,14 @@ flowchart TB
    
    A(v0.0.1) --> B(v0.0.4)
 {{</mermaid>}} |
-| skips | `ID(<bundle tag>) x--x | <versions that should be skipped> | ID(<bundle tag>)` | {{<mermaid>}}
+| skips | `ID(<bundle tag>) x--x \| <versions that should be skipped> \| ID(<bundle tag>)` | {{<mermaid>}}
 flowchart TB
    classDef head fill:#ffbfcf;
    classDef installed fill:#34ebba;
    
    A(v0.0.1) x--x |v0.0.2,v0.0.3| B(v0.0.4)
 {{</mermaid>}} |
-| skipRange | `ID<bundle tag>) o--o | <range> | ID(<bundle tag>)` | {{<mermaid>}}
+| skipRange | `ID<bundle tag>) o--o \| <range> \| ID(<bundle tag>)` | {{<mermaid>}}
 flowchart TB
    classDef head fill:#ffbfcf;
    classDef installed fill:#34ebba;
@@ -213,14 +213,14 @@ flowchart TB
    
    A(v0.0.1) -.-> B(v0.0.4)
 {{</mermaid>}} |
-| future skips | `ID(<bundle tag>) x-.-x | <versions that should be skipped> | ID(<bundle tag>)` | {{<mermaid>}}
+| future skips | `ID(<bundle tag>) x-.-x \| <versions that should be skipped> \| ID(<bundle tag>)` | {{<mermaid>}}
 flowchart TB
    classDef head fill:#ffbfcf;
    classDef installed fill:#34ebba;
    
    A(v0.0.1) x-.-x |v0.0.2,v0.0.3| B(v0.0.4)
 {{</mermaid>}} |
-| future skipRange | `ID<bundle tag>) o-.-o | <range> | ID(<bundle tag>)` | {{<mermaid>}}
+| future skipRange | `ID<bundle tag>) o-.-o \| <range> \| ID(<bundle tag>)` | {{<mermaid>}}
 flowchart TB
    classDef head fill:#ffbfcf;
    classDef installed fill:#34ebba;


### PR DESCRIPTION
It is not an issue with the current version of Hugo as it gets rendered as expected. However newer versions of Hugo use goldmark to render markdown with an extension which implements [GitHub Flavored Markdown: Tables](https://github.github.com/gfm/#tables-extension-). 

Accordingly to the spec pipe in a cell’s content needs be escaping ([example](https://github.github.com/gfm/#example-200)).

As a result of proper spec implementation in goldmark tables & graphs get broken with new versions of Hugo.