### PR TITLE
Switches to `.RelPermalink` from `.URL`

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -7,7 +7,7 @@
     </a>
     <nav class="of-nav-main nav-collapse">
       <ul class="of-nav-main__items menu-items">
-        <li class="of-nav-main__item"><a class="of-link-list__a {{ if eq .URL "/" }} of-m-active {{end}}" href="/">Home</a></li>
+        <li class="of-nav-main__item"><a class="of-link-list__a {{ if eq .RelPermalink "/" }} of-m-active {{end}}" href="/">Home</a></li>
         {{ $currentPage := . }}
         {{ range .Site.Menus.main }}
         <li class="of-nav-main__item"><a class="of-link-list__a{{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} of-m-active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a></li>


### PR DESCRIPTION
`.URL` was depricated and removed in Hugo 0.93.

This is a prep to Hugo upgrade.