### PR TITLE
Add composite template docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -34,6 +34,8 @@ pygmentsStyle = "tango"
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
+  [markup.tableOfContents]
+    endLevel = 4
 
 # Image processing configuration.
 [imaging]

--- a/layouts/shortcodes/code_callout.html
+++ b/layouts/shortcodes/code_callout.html
@@ -1,0 +1,1 @@
+<span class="code-callout"><b style="border:5px solid crimson; color:whitesmoke; border-radius: 30%;background-color: crimson; font-size: x-small;">{{ index .Params 0 }}</b></span>


### PR DESCRIPTION
**Description**
- Adds documentation on the composite template introduced to opm via the `opm alpha render-template composite` subcommand