### PR TITLE
Removes enableGitInfo config param

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,9 +7,6 @@ enableRobotsTXT = true
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
 theme = "docsy"
 
-# Will give values to .Lastmod etc.
-enableGitInfo = true
-
 # Language settings
 contentDir = "content/en"
 defaultContentLanguage = "en"
@@ -125,5 +122,3 @@ no = 'Sorry to hear that. Please <a href="https://github.com/operator-framework/
 	name = "github"
 	url = "https://github.com/operator-framework/operator-lifecycle-manager"
 	icon = "fab fa-github"
-
-

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,6 @@
 
 [build.environment]
   HUGO_VERSION = "0.66.0"
-  HUGO_ENABLEGITINFO = "true"
 
 [context.production.environment]
   HUGO_ENV = "production"
@@ -31,4 +30,4 @@
 
 [[redirects]]
   from = "/docs/tasks/make-index-available-on-cluster"
-  to = "/docs/tasks/make-catalog-available-on-cluster" 
+  to = "/docs/tasks/make-catalog-available-on-cluster"

--- a/themes/docsy/layouts/partials/page-meta-lastmod.html
+++ b/themes/docsy/layouts/partials/page-meta-lastmod.html
@@ -1,1 +1,3 @@
-{{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}
+{{ if and (.GitInfo) (.Site.Params.github_repo) -}}
+    {{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}
+{{ end -}}


### PR DESCRIPTION
Default value is false. This effectively disables "Last modified" at the end of the page in docs.

As per discussion [here](https://github.com/operator-framework/olm-docs/pull/284#issuecomment-1503440816).