### PR TITLE
channeltypepreference attribute for semver template; providing hyperlinks to example sections

### DIFF
--- a/content/en/docs/Reference/catalog-templates.md
+++ b/content/en/docs/Reference/catalog-templates.md
@@ -255,7 +255,7 @@ The `olm.semver` [cue](https://cuelang.org/docs/references/spec/) schema is:
   GenerateMajorChannels?: bool
 
   // optional flag to prefer major- or minor-version channels, when both are generated and identical in stability and version
-  ChannelTypePreference?: bool
+  DefaultChannelTypePreference?: bool
 
   // optional candidate channel
   Candidate?: {
@@ -537,9 +537,9 @@ package: testoperator
 schema: olm.channel
 ```
 
-In this situation, both channels have matching channel archetypes and the channel heads have the same versions.  The `ChannelTypePreference` attribute allows us to deterministically select a single channel in this case.  This attribute defaults to prefer minor-version channels (`ChannelTypePreference: minor`), but can be overridden in the schema if the author wishes to prefer major-version channels instead (`ChannelTypePreference: major`). 
+In this situation, both channels have matching channel archetypes and the channel heads have the same versions.  The `DefaultChannelTypePreference` attribute allows us to deterministically select a single channel in this case.  This attribute defaults to prefer minor-version channels (`DefaultChannelTypePreference: minor`), but can be overridden in the schema if the author wishes to prefer major-version channels instead (`DefaultChannelTypePreference: major`). 
 
-With `ChannelTypePreference` set to `major`, our most-stable channels and package output would looks like
+With `DefaultChannelTypePreference` set to `major`, our most-stable channels and package output would look like
 ```yaml
 ---
 defaultChannel: stable-v1

--- a/content/en/docs/Reference/catalog-templates.md
+++ b/content/en/docs/Reference/catalog-templates.md
@@ -254,8 +254,8 @@ The `olm.semver` [cue](https://cuelang.org/docs/references/spec/) schema is:
   // optional flag to control generating major-version channels, defaults to _false_ if unspecified
   GenerateMajorChannels?: bool
 
-  // optional flag to prefer major- or minor-version channels, when both are generated and identical in stability and version
-  DefaultChannelTypePreference?: bool
+  // optional preference for major- or minor-version channels, when both are generated and identical in stability and version
+  DefaultChannelTypePreference?: string
 
   // optional candidate channel
   Candidate?: {
@@ -517,7 +517,7 @@ In the case that we generate both major-version and minor-version channels:
 
 ```yaml
 GenerateMinorChannels: true
-GenerateMajorChannels: false
+GenerateMajorChannels: true
 ```
 
 we can easily end up in a situation where our results yield indifferentiable results, for e.g.:


### PR DESCRIPTION
Introducing a new semver template attribute which provides authors the capability to deterministically select generated major or minor channels as default when they are for all other measures "equally stable". 

This attribute is defaulted to minor-version channels if omitted. 

Changes visible in the [Catalog Templates](https://deploy-preview-296--operator-lifecycle-manager.netlify.app/docs/reference/catalog-templates/) page. 
