### PR TITLE
OPECO-3073: Add Note for CRD Version Spec

### DIFF
--- a/content/en/docs/Concepts/crds/clusterserviceversion.md
+++ b/content/en/docs/Concepts/crds/clusterserviceversion.md
@@ -96,7 +96,6 @@ spec:
     # name is the metadata.name of the CRD (which is of the form <plural>.<group>)
     - name: memcacheds.cache.example.com
       # version is the spec.versions[].name value defined in the CRD
-      # while version is not required, semver template functionality relies on its presence
       version: v1alpha1
       # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
       kind: Memcached

--- a/content/en/docs/Concepts/crds/clusterserviceversion.md
+++ b/content/en/docs/Concepts/crds/clusterserviceversion.md
@@ -96,6 +96,7 @@ spec:
     # name is the metadata.name of the CRD (which is of the form <plural>.<group>)
     - name: memcacheds.cache.example.com
       # version is the spec.versions[].name value defined in the CRD
+      # while version is not required, semver template functionality relies on its presence
       version: v1alpha1
       # kind is the CamelCased singular value defined in spec.names.kind of the CRD.
       kind: Memcached

--- a/content/en/docs/Reference/catalog-templates.md
+++ b/content/en/docs/Reference/catalog-templates.md
@@ -235,7 +235,7 @@ This alpha version of the `semver template` has the following goals:
 - minor-version (Y-stream) and major-version (X-stream) versioning capabilities
 - clear mapping between input schema and output FBC attributes
 
-Note: The semver template depends on the optional `csv.spec.version` field. If you want to use the semver catalog template, you must specify a version in your extension's CSV.
+>**Note:** The semver template depends on the optional `csv.spec.version` field. If you want to use the semver catalog template, you must specify a version in your extension's CSV.
 
 ### Specification
 Like best practices [recommended channel naming](/docs/best-practices/channel-naming/#recommended-channel-naming), this template supports channel names `Candidate`, `Fast`, and `Stable`, in order of increasing channel stability. We leverage this relationship when calculating the default channel for the package. 

--- a/content/en/docs/Reference/catalog-templates.md
+++ b/content/en/docs/Reference/catalog-templates.md
@@ -235,6 +235,8 @@ This alpha version of the `semver template` has the following goals:
 - minor-version (Y-stream) and major-version (X-stream) versioning capabilities
 - clear mapping between input schema and output FBC attributes
 
+Note: `csv.spec.version` is optional in the API definition, however the field is required if you want to use the `semver template` for your catalog.
+
 ### Specification
 Like best practices [recommended channel naming](/docs/best-practices/channel-naming/#recommended-channel-naming), this template supports channel names `Candidate`, `Fast`, and `Stable`, in order of increasing channel stability. We leverage this relationship when calculating the default channel for the package. 
 

--- a/content/en/docs/Reference/catalog-templates.md
+++ b/content/en/docs/Reference/catalog-templates.md
@@ -235,7 +235,7 @@ This alpha version of the `semver template` has the following goals:
 - minor-version (Y-stream) and major-version (X-stream) versioning capabilities
 - clear mapping between input schema and output FBC attributes
 
-Note: `csv.spec.version` is optional in the API definition, however the field is required if you want to use the `semver template` for your catalog.
+Note: The semver template depends on the optional `csv.spec.version` field. If you want to use the semver catalog template, you must specify a version in your extension's CSV.
 
 ### Specification
 Like best practices [recommended channel naming](/docs/best-practices/channel-naming/#recommended-channel-naming), this template supports channel names `Candidate`, `Fast`, and `Stable`, in order of increasing channel stability. We leverage this relationship when calculating the default channel for the package. 


### PR DESCRIPTION
This addresses the note from #311 informing users that the version spec is necessary for semver templates. 

Solves #311 