### PR TITLE
Update catalog-templates.md - Remove deprecated image from examples

### DIFF
--- a/content/en/docs/Reference/catalog-templates.md
+++ b/content/en/docs/Reference/catalog-templates.md
@@ -94,8 +94,6 @@ properties:
     packageName: example-operator
     version: 0.1.0
 relatedImages:
-- image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-  name: ""
 - image: docker.io/example/example-operator-bundle:0.1.0
   name: ""
 - image: docker.io/example/example-operator:0.1.0


### PR DESCRIPTION
The kube-rbac-proxy from upstream is deprecated. Therefore, it's better not to include it in the examples since we do not promote its usage. PS. it does not seems to bring any value